### PR TITLE
Bump to v0.4

### DIFF
--- a/microsoft_wd_atp/node.py
+++ b/microsoft_wd_atp/node.py
@@ -388,6 +388,13 @@ class Output(ActorBaseFT):
             value
         )
 
+    def mgmtbus_status(self):
+        result = super(ActorBaseFT, self).mgmtbus_status()
+        result['sub_state'] = 'ERROR'
+        result['sub_state_message'] = 'This node is deprecated'
+
+        return result
+
     def length(self, source=None):
         return self._queue.qsize()
 

--- a/microsoft_wd_atp/prototypes/microsoft_wd_atp.yml
+++ b/microsoft_wd_atp/prototypes/microsoft_wd_atp.yml
@@ -6,17 +6,18 @@ prototypes:
   output:
     author: Palo Alto Networks TBD
     class: microsoft_wd_atp.Output
-    development_status: EXPERIMENTAL
+    development_status: DEPRECATED
     node_type: output
     indicator_types:
       - URL
       - IPv4
       - domain
     tags:
+      - deprecated
       - extension
       - wd-atp
     description: >
-      Output node for Microsoft Windows Defender ATP API
+      Output node for Microsoft Windows Defender ATP API - DEPRECATED
     config: {}
 
   outputBatch:

--- a/microsoft_wd_atp/webui/extension.js
+++ b/microsoft_wd_atp/webui/extension.js
@@ -10,6 +10,7 @@ function MSFTWDATPSideConfigController($scope, MinemeldConfigService, MineMeldRu
     vm.client_id = undefined;
     vm.client_secret = undefined;
     vm.tenant_id = undefined;
+    vm.action = undefined;
 
     vm.loadSideConfig = function() {
         var nodename = $scope.$parent.vm.nodename;
@@ -37,11 +38,18 @@ function MSFTWDATPSideConfigController($scope, MinemeldConfigService, MineMeldRu
             } else {
                 vm.tenant_id = undefined;
             }
+            
+            if (result.action) {
+                vm.action = result.action;
+            } else {
+                vm.action = undefined;
+            }
         }, (error) => {
             toastr.error('ERROR RETRIEVING NODE SIDE CONFIG: ' + error.status);
             vm.client_id = undefined;
             vm.client_secret = undefined;
             vm.tenant_id = undefined;
+            vm.action = undefined;
         });
     };
 
@@ -58,6 +66,9 @@ function MSFTWDATPSideConfigController($scope, MinemeldConfigService, MineMeldRu
         }
         if (vm.tenant_id) {
             side_config.tenant_id = vm.tenant_id;
+        }
+        if (vm.action) {
+            side_config.action = vm.action;
         }
 
         return MinemeldConfigService.saveDataFile(
@@ -88,6 +99,7 @@ function MSFTWDATPSideConfigController($scope, MinemeldConfigService, MineMeldRu
             });
         });
     };
+    
     vm.setClientSecret = function() {
         var mi = $modal.open({
             templateUrl: '/extensions/webui/microsoftWDATPWebui/wdatp.output.scs.modal.html',
@@ -127,6 +139,28 @@ function MSFTWDATPSideConfigController($scope, MinemeldConfigService, MineMeldRu
                 vm.loadSideConfig();
             }, (error) => {
                 toastr.error('ERROR SETTING TENANT ID: ' + error.statusText);
+            });
+        });
+    };
+
+    vm.setAction = function() {
+        var mi = $modal.open({
+            templateUrl: '/extensions/webui/microsoftWDATPWebui/wdatp.output.action.modal.html',
+            controller: ['$modalInstance', MSFTWDATPActionController],
+            controllerAs: 'vm',
+            bindToController: true,
+            backdrop: 'static',
+            animation: false
+        });
+
+        mi.result.then((result) => {
+            vm.action = result.action;
+
+            return vm.saveSideConfig().then((result) => {
+                toastr.success('ACTION SET');
+                vm.loadSideConfig();
+            }, (error) => {
+                toastr.error('ERROR SETTING ACTION: ' + error.statusText);
             });
         });
     };
@@ -213,6 +247,32 @@ function MSFTWDATPTenantIDController($modalInstance) {
         var result = {};
 
         result.tenant_id = vm.tenant_id;
+
+        $modalInstance.close(result);
+    }
+
+    vm.cancel = function() {
+        $modalInstance.dismiss();
+    }
+}
+
+function MSFTWDATPActionController($modalInstance) {
+    var vm = this;
+
+    vm.availableActions = ['Alert', 'AlertAndBlock', 'Allowed'];
+    vm.action = undefined;
+    vm.valid = function() {
+        if (!vm.action) {
+            return false;
+        }
+
+        return true;
+    };
+
+    vm.save = function() {
+        var result = {};
+
+        result.action = vm.action;
 
         $modalInstance.close(result);
     }

--- a/microsoft_wd_atp/webui/wdatp.output.action.modal.html
+++ b/microsoft_wd_atp/webui/wdatp.output.action.modal.html
@@ -1,0 +1,24 @@
+<div class="modal-header">
+    <h1 class="modal-title">ACTION</h1>
+</div>
+<div class="modal-body">
+    <div class="row">
+        <form class="config-add-form form-horizontal m-t-xs">
+            <div class="form-group">
+                <label class="col-xs-4 control-label">ACTION</label>
+                <div class="col-xs-6">
+                    <ui-select ng-model="vm.action" theme="bootstrap" on-select="vm.valid()" on-remove="vm.valid()">
+                        <ui-select-match placeholder="Select action...">{{$select.selected}}</ui-select-match>
+                        <ui-select-choices repeat="availAction in vm.availableActions | filter:$select.search">
+                            {{availAction}}
+                        </ui-select-choices>
+                    </ui-select>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+<div class="modal-footer">
+    <button ng-disabled="!vm.valid()" class="btn btn-primary btn-sm" type="button" ng-click="vm.save()">OK</button>
+    <button class="btn btn-warning btn-sm" type="button" ng-click="vm.cancel()">CANCEL</button>
+</div>

--- a/microsoft_wd_atp/webui/wdatp.output.info.html
+++ b/microsoft_wd_atp/webui/wdatp.output.info.html
@@ -24,7 +24,12 @@
                 </tr>
                 <tr>
                     <td>STATE</td>
-                    <td ng-switch on="vm.nodeState.state">
+                    <td ng-if="vm.nodeState.sub_state && vm.nodeState.sub_state === 'ERROR'">
+                        <span class="label label-danger"
+                            tooltip="{{ vm.nodeState.sub_state_message }}"
+                            ng-bind="vm.nodeState.sub_state"></span>
+                    </td>
+                    <td ng-if="!vm.nodeState.sub_state" ng-switch on="vm.nodeState.state">
                         <span ng-switch-when="5" class="label label-success">{{ vm.nodeState.stateAsString }}</span>
                         <span ng-switch-default class="label label-warning">{{ vm.nodeState.stateAsString }}</span>
                     </td>

--- a/microsoft_wd_atp/webui/wdatp.output.info.html
+++ b/microsoft_wd_atp/webui/wdatp.output.info.html
@@ -93,6 +93,13 @@
                         <span ng-if="sideConfig.tenant_id">{{ sideConfig.tenant_id }}</span>
                     </td>
                 </tr>
+                <tr>
+                    <td>ACTION</td>
+                    <td tooltip="action" class="nodedetail-info-clickable" ng-click="sideConfig.setAction()">
+                        <span ng-if="!sideConfig.action"><em>Not set</em></span>
+                        <span ng-if="sideConfig.action">{{ sideConfig.action }}</span>
+                    </td>
+                </tr>                
             </tbody>
         </table>
     </div>

--- a/minemeld.json
+++ b/minemeld.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.3",
+    "version": "0.4",
     "name": "minemeld-wd-atp",
     "author": "Palo Alto Networks",
     "author_email": "techbizdev@paloaltonetworks.com",


### PR DESCRIPTION
- Deprecated old (non-batch) WDATP API support: must use only "batch" output node
- Added support for IPV4 CIDRs and Changes
- Added support for action: Alert Only, Alert & Block, Allow
- Improved error checks