### PR TITLE
Severity feature

### DIFF
--- a/microsoft_wd_atp/node.py
+++ b/microsoft_wd_atp/node.py
@@ -496,6 +496,11 @@ class OutputBatch(ActorBaseFT):
             self.action = action
             LOG.info('{} - action set'.format(self.action))
 
+        severity = sconfig.get('severity', None)
+        if severity is not None:
+            self.severity = severity
+            LOG.info('{} - severity set'.format(self.name))
+
     def connect(self, inputs, output):
         output = False
         super(OutputBatch, self).connect(inputs, output)

--- a/microsoft_wd_atp/webui/extension.js
+++ b/microsoft_wd_atp/webui/extension.js
@@ -11,6 +11,7 @@ function MSFTWDATPSideConfigController($scope, MinemeldConfigService, MineMeldRu
     vm.client_secret = undefined;
     vm.tenant_id = undefined;
     vm.action = undefined;
+    vm.severity = undefined;
 
     vm.loadSideConfig = function() {
         var nodename = $scope.$parent.vm.nodename;
@@ -44,12 +45,19 @@ function MSFTWDATPSideConfigController($scope, MinemeldConfigService, MineMeldRu
             } else {
                 vm.action = undefined;
             }
+
+            if (result.severity) {
+                vm.severity = result.severity;
+            } else {
+                vm.severity = undefined;
+            }
         }, (error) => {
             toastr.error('ERROR RETRIEVING NODE SIDE CONFIG: ' + error.status);
             vm.client_id = undefined;
             vm.client_secret = undefined;
             vm.tenant_id = undefined;
             vm.action = undefined;
+            vm.severity = undefined;
         });
     };
 
@@ -69,6 +77,9 @@ function MSFTWDATPSideConfigController($scope, MinemeldConfigService, MineMeldRu
         }
         if (vm.action) {
             side_config.action = vm.action;
+        }
+        if (vm.severity) {
+            side_config.severity = vm.severity;
         }
 
         return MinemeldConfigService.saveDataFile(
@@ -164,6 +175,28 @@ function MSFTWDATPSideConfigController($scope, MinemeldConfigService, MineMeldRu
             });
         });
     };
+
+    vm.setSeverity = function() {
+        var mi = $modal.open({
+            templateUrl: '/extensions/webui/microsoftWDATPWebui/wdatp.output.severity.modal.html',
+            controller: ['$modalInstance', MSFTWDATPSeverityController],
+            controllerAs: 'vm',
+            bindToController: true,
+            backdrop: 'static',
+            animation: false
+        });
+
+        mi.result.then((result) => {
+            vm.severity = result.severity;
+
+            return vm.saveSideConfig().then((result) => {
+                toastr.success('SEVERITY SET');
+                vm.loadSideConfig();
+            }, (error) => {
+                toastr.error('ERROR SETTING SEVERITY: ' + error.statusText);
+            });
+        })
+    }
 
     vm.loadSideConfig();
 }
@@ -281,6 +314,32 @@ function MSFTWDATPActionController($modalInstance) {
         $modalInstance.dismiss();
     }
 }
+
+function MSFTWDATPSeverityController($modalInstance) {
+    var vm = this;
+
+    vm.availableSeverity = ['Informational', 'Low', 'Medium', 'High'];
+    vm.severity = undefined;
+    vm.valid = function() {
+        if (!vm.severity) {
+            return false;
+        }
+
+        return true;
+    };
+
+    vm.save = function() {
+        var result = {};
+
+        result.severity = vm.severity;
+
+        $modalInstance.close(result);
+    };
+
+    vm.cancel = function() {
+        $modalInstance.dismiss();
+    };
+};
 
 angular.module('microsoftWDATPWebui', [])
     .controller('MSFTWDATPSideConfigController', [

--- a/microsoft_wd_atp/webui/wdatp.output.info.html
+++ b/microsoft_wd_atp/webui/wdatp.output.info.html
@@ -104,6 +104,13 @@
                         <span ng-if="!sideConfig.action"><em>Not set</em></span>
                         <span ng-if="sideConfig.action">{{ sideConfig.action }}</span>
                     </td>
+                </tr>
+                <tr>
+                    <td>SEVERITY</td>
+                    <td tooltip="action" class="nodedetail-info-clickable" ng-click="sideConfig.setSeverity()">
+                        <span ng-if="!sideConfig.severity"><em>Not set</em></span>
+                        <span ng-if="sideConfig.severity">{{ sideConfig.severity }}</span>
+                    </td>
                 </tr>                
             </tbody>
         </table>

--- a/microsoft_wd_atp/webui/wdatp.output.severity.modal.html
+++ b/microsoft_wd_atp/webui/wdatp.output.severity.modal.html
@@ -1,0 +1,24 @@
+<div class="modal-header">
+    <h1 class="modal-title">SEVERITY</h1>
+</div>
+<div class="modal-body">
+    <div class="row">
+        <form class="config-add-form form-horizontal m-t-xs">
+            <div class="form-group">
+                <label class="col-xs-4 control-label">SEVERITY</label>
+                <div class="col-xs-6">
+                    <ui-select ng-model="vm.severity" theme="bootstrap" on-select="vm.valid()" on-remove="vm.valid()">
+                        <ui-select-match placeholder="Select severity...">{{$select.selected}}</ui-select-match>
+                        <ui-select-choices repeat="availSeverity in vm.availableSeverity | filter:$select.search">
+                            {{availSeverity}}
+                        </ui-select-choices>
+                    </ui-select>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+<div class="modal-footer">
+    <button ng-disabled="!vm.valid()" class="btn btn-primary btn-sm" type="button" ng-click="vm.save()">OK</button>
+    <button class="btn btn-warning btn-sm" type="button" ng-click="vm.cancel()">CANCEL</button>
+</div>


### PR DESCRIPTION
## Description

Add pick-list for MSFT supported severity levels to the output node UI and logic to add the assigned severity value to the API call. 

## Motivation and Context

Severity in MSFT Defender ATP is useful for triggering alerts and prioritizing actions.
Issue #11 https://github.com/PaloAltoNetworks/minemeld-wd-atp/issues/11

## How Has This Been Tested?

Installed modified extension on fresh install of Minemeld v0.9.70.  Configured output node for tenant and added IOCs to assigned input node.  Verified IOCs were successfully imported into MSFT Defender ATP and the severity value was set correctly.  Changed severity value in output node UI and reran IOC add test to verify each severity value was successful.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
